### PR TITLE
potentially fix "attempt to apply non-function"

### DIFF
--- a/R/groupComparisonPlots.R
+++ b/R/groupComparisonPlots.R
@@ -98,7 +98,7 @@ groupComparisonPlots = function(
     all_labels = as.character(unique(data$Label))
     log_base_FC = ifelse(is.element("log2FC", colnames(data)), 2, 10)
     
-    getOption("MSstatsLog")("MSstats - groupComparisonPlots function")
+    getOption("MSstatsLog")("INFO", "MSstats - groupComparisonPlots function")
     chosen_labels = .checkGCPlotsInput(type, logBase.pvalue, which.Comparison,
                                        all_labels)
     input = input[Label %in% chosen_labels]


### PR DESCRIPTION
I have no idea why this only came up in our case and how this is triggered but compared to the other log statements in your code, this line looked different. I could not test it yet, though.

Error:
`<simpleError in getOption("MSstatsLog")("MSstats - groupComparisonPlots function"): attempt to apply non-function>`