### PR TITLE
fix documentation for dataProcess and groupComparison

### DIFF
--- a/R/dataProcess.R
+++ b/R/dataProcess.R
@@ -1,6 +1,6 @@
 #' Process MS data: clean, normalize and summarize before differential analysis
 #' 
-#' @param raw name of the raw (input) data set.
+#' @param raw a data.frame of feature-level intensities in MSstats long format.
 #' @param logTrans base of logarithm transformation: 2 (default) or 10.
 #' @param normalization normalization to remove systematic bias between MS runs. 
 #' There are three different normalizations supported:
@@ -67,7 +67,7 @@
 #' @importFrom utils sessionInfo
 #' @importFrom data.table as.data.table
 #' 
-#' @return A list containing:
+#' @return A list of three elements:
 #' \describe{
 #'   \item{FeatureLevelData}{A data frame with feature-level information after processing. Columns include:
 #'     \describe{
@@ -86,23 +86,32 @@
 #'       \item{ABUNDANCE}{Processed abundance or intensity value after log-transformation and normalization.}
 #'       \item{newABUNDANCE}{The ABUNDANCE column but includes imputed missing values. It is the column that is used for protein summarization.}
 #'       \item{predicted}{Predicted intensity values for censored data, typically derived from a statistical model.}
+#'       \item{remove}{Logical indicator of whether the feature was excluded from run-level summarization by feature selection. Present only when featureSubset = "topN" (the default) or "top3".}
 #'     }
+#'     Two further columns are present only when featureSubset = "highQuality":
+#'     \code{feature_quality} ("Informative" or "Uninformative") and
+#'     \code{is_outlier} (logical). A logical \code{is_labeled_ref} column is present
+#'     for label-based experiments that contain a heavy reference and are normalized
+#'     with "equalizeMedians".
 #'   }
 #'   \item{ProteinLevelData}{A data frame with run-level summarized information for each protein. Columns include:
 #'     \describe{
 #'       \item{RUN}{Identifier for the specific MS run.}
 #'       \item{Protein}{Identifier for the protein.}
+#'       \item{LABEL}{Specifies the isotopic labeling of the summarized peptides: "L" for light-labeled, "H" for heavy-labeled.}
 #'       \item{LogIntensities}{Log-transformed intensities for the protein in each run.}
 #'       \item{originalRUN}{Original run identifier before any processing.}
 #'       \item{GROUP}{Experimental group identifier.}
 #'       \item{SUBJECT}{Subject identifier within the experimental group.}
 #'       \item{TotalGroupMeasurements}{Total number of feature measurements for the protein in the given group.}
-#'       \item{NumMeasuredFeatures}{Number of features measured for the protein in the given run.}
-#'       \item{MissingPercentage}{Percentage of missing feature values for the protein in the given run.}
+#'       \item{NumMeasuredFeature}{Number of features measured for the protein in the given run.}
+#'       \item{MissingPercentage}{Percentage (between 0 and 1) of missing feature values for the protein in the given run.}
 #'       \item{more50missing}{Logical indicator of whether more than 50 percent of the features values are missing for the protein in the given run.}
 #'       \item{NumImputedFeature}{Number of features for which values were imputed due to missing or censored data for the protein in the given run.}
 #'     }
 #'   }
+#'   \item{SummaryMethod}{A character string recording the summarization method that
+#'     was used, i.e. the value of \code{summaryMethod}: "TMP" or "linear".}
 #' }
 #' 
 #' @export

--- a/R/groupComparison.R
+++ b/R/groupComparison.R
@@ -33,21 +33,22 @@
 #'       \item{pvalue}{The p-value for the statistical test of the comparison. Applicable if degrees of freedom is greater than 0}
 #'       \item{adj.pvalue}{The adjusted p-value using the Benjamini-Hochberg method for controlling the false discovery rate.}
 #'       \item{issue}{Any issues encountered during the comparison.  NA indicates no issues. "oneConditionMissing" occurs when data for one of the conditions being compared is entirely missing for a particular protein.}
-#'       \item{MissingPercentage}{The percentage of missing features for a given protein across all runs. This column is included only if missing values were imputed.}
-#'       \item{ImputationPercentage}{The percentage of features that were imputed for a given protein across all runs. This column is included only if missing values were imputed.}
+#'       \item{MissingPercentage}{The percentage (between 0 and 1) of missing features for a given protein across all runs. This column is included only if missing values were imputed.}
+#'       \item{ImputationPercentage}{The percentage (between 0 and 1) of features that were imputed for a given protein across all runs. This column is included only if missing values were imputed.}
 #'     }
 #'   }
 #'   \item{ModelQC}{A `data.frame` containing quality control data used to fit models for group comparison. The columns include:
 #'     \describe{
 #'       \item{RUN}{Identifier for the specific MS run.}
 #'       \item{Protein}{Identifier for the protein.}
+#'       \item{LABEL}{Specifies the isotopic labeling of the summarized peptides: "L" for light-labeled, "H" for heavy-labeled.}
 #'       \item{ABUNDANCE}{Summarized intensity for the protein in a given run.}
 #'       \item{originalRUN}{Original run identifier before any processing.}
 #'       \item{GROUP}{Experimental group identifier.}
 #'       \item{SUBJECT}{Subject identifier within the experimental group.}
 #'       \item{TotalGroupMeasurements}{Total number of feature measurements for the protein in the given group.}
-#'       \item{NumMeasuredFeatures}{Number of features measured for the protein in the given run.}
-#'       \item{MissingPercentage}{Percentage of missing feature values for the protein in the given run.}
+#'       \item{NumMeasuredFeature}{Number of features measured for the protein in the given run.}
+#'       \item{MissingPercentage}{Percentage (between 0 and 1) of missing feature values for the protein in the given run.}
 #'       \item{more50missing}{Logical indicator of whether more than 50 percent of the features values are missing for the protein in the given run.}
 #'       \item{NumImputedFeature}{Number of features for which values were imputed due to missing or censored data for the protein in the given run.}
 #'       \item{residuals}{Contains the differences between the observed values and the values predicted by the fitted model. }

--- a/man/dataProcess.Rd
+++ b/man/dataProcess.Rd
@@ -29,7 +29,7 @@ dataProcess(
 )
 }
 \arguments{
-\item{raw}{name of the raw (input) data set.}
+\item{raw}{a data.frame of feature-level intensities in MSstats long format.}
 
 \item{logTrans}{base of logarithm transformation: 2 (default) or 10.}
 
@@ -123,7 +123,7 @@ track progress. Only works for Linux & Mac OS. Default is 1.}
 \item{aft_iterations}{Number of iterations for AFT model fitting. Default is 90.}
 }
 \value{
-A list containing:
+A list of three elements:
 \describe{
   \item{FeatureLevelData}{A data frame with feature-level information after processing. Columns include:
     \describe{
@@ -142,23 +142,32 @@ A list containing:
       \item{ABUNDANCE}{Processed abundance or intensity value after log-transformation and normalization.}
       \item{newABUNDANCE}{The ABUNDANCE column but includes imputed missing values. It is the column that is used for protein summarization.}
       \item{predicted}{Predicted intensity values for censored data, typically derived from a statistical model.}
+      \item{remove}{Logical indicator of whether the feature was excluded from run-level summarization by feature selection. Present only when featureSubset = "topN" (the default) or "top3".}
     }
+    Two further columns are present only when featureSubset = "highQuality":
+    \code{feature_quality} ("Informative" or "Uninformative") and
+    \code{is_outlier} (logical). A logical \code{is_labeled_ref} column is present
+    for label-based experiments that contain a heavy reference and are normalized
+    with "equalizeMedians".
   }
   \item{ProteinLevelData}{A data frame with run-level summarized information for each protein. Columns include:
     \describe{
       \item{RUN}{Identifier for the specific MS run.}
       \item{Protein}{Identifier for the protein.}
+      \item{LABEL}{Specifies the isotopic labeling of the summarized peptides: "L" for light-labeled, "H" for heavy-labeled.}
       \item{LogIntensities}{Log-transformed intensities for the protein in each run.}
       \item{originalRUN}{Original run identifier before any processing.}
       \item{GROUP}{Experimental group identifier.}
       \item{SUBJECT}{Subject identifier within the experimental group.}
       \item{TotalGroupMeasurements}{Total number of feature measurements for the protein in the given group.}
-      \item{NumMeasuredFeatures}{Number of features measured for the protein in the given run.}
-      \item{MissingPercentage}{Percentage of missing feature values for the protein in the given run.}
+      \item{NumMeasuredFeature}{Number of features measured for the protein in the given run.}
+      \item{MissingPercentage}{Percentage (between 0 and 1) of missing feature values for the protein in the given run.}
       \item{more50missing}{Logical indicator of whether more than 50 percent of the features values are missing for the protein in the given run.}
       \item{NumImputedFeature}{Number of features for which values were imputed due to missing or censored data for the protein in the given run.}
     }
   }
+  \item{SummaryMethod}{A character string recording the summarization method that
+    was used, i.e. the value of \code{summaryMethod}: "TMP" or "linear".}
 }
 }
 \description{

--- a/man/groupComparison.Rd
+++ b/man/groupComparison.Rd
@@ -63,21 +63,22 @@ A list with the following components:
       \item{pvalue}{The p-value for the statistical test of the comparison. Applicable if degrees of freedom is greater than 0}
       \item{adj.pvalue}{The adjusted p-value using the Benjamini-Hochberg method for controlling the false discovery rate.}
       \item{issue}{Any issues encountered during the comparison.  NA indicates no issues. "oneConditionMissing" occurs when data for one of the conditions being compared is entirely missing for a particular protein.}
-      \item{MissingPercentage}{The percentage of missing features for a given protein across all runs. This column is included only if missing values were imputed.}
-      \item{ImputationPercentage}{The percentage of features that were imputed for a given protein across all runs. This column is included only if missing values were imputed.}
+      \item{MissingPercentage}{The percentage (between 0 and 1) of missing features for a given protein across all runs. This column is included only if missing values were imputed.}
+      \item{ImputationPercentage}{The percentage (between 0 and 1) of features that were imputed for a given protein across all runs. This column is included only if missing values were imputed.}
     }
   }
   \item{ModelQC}{A `data.frame` containing quality control data used to fit models for group comparison. The columns include:
     \describe{
       \item{RUN}{Identifier for the specific MS run.}
       \item{Protein}{Identifier for the protein.}
+      \item{LABEL}{Specifies the isotopic labeling of the summarized peptides: "L" for light-labeled, "H" for heavy-labeled.}
       \item{ABUNDANCE}{Summarized intensity for the protein in a given run.}
       \item{originalRUN}{Original run identifier before any processing.}
       \item{GROUP}{Experimental group identifier.}
       \item{SUBJECT}{Subject identifier within the experimental group.}
       \item{TotalGroupMeasurements}{Total number of feature measurements for the protein in the given group.}
-      \item{NumMeasuredFeatures}{Number of features measured for the protein in the given run.}
-      \item{MissingPercentage}{Percentage of missing feature values for the protein in the given run.}
+      \item{NumMeasuredFeature}{Number of features measured for the protein in the given run.}
+      \item{MissingPercentage}{Percentage (between 0 and 1) of missing feature values for the protein in the given run.}
       \item{more50missing}{Logical indicator of whether more than 50 percent of the features values are missing for the protein in the given run.}
       \item{NumImputedFeature}{Number of features for which values were imputed due to missing or censored data for the protein in the given run.}
       \item{residuals}{Contains the differences between the observed values and the values predicted by the fitted model. }


### PR DESCRIPTION
# Motivation and Context

Fixed parts of dataProcess() and groupComparison() documentation to match the utils_output.R.

The @return blocks of the above functions return different/more objects (verified against live output on DDARawData) that weren't documented.

## Changes

- Renamed `NumMeasuredFeatures` to `NumMeasuredFeature` in both @return blocks.
  - I can also change the output column in utils_output.R instead but I chose to do it here to avoid breaking any downstream code.
- Documented previously missing pieces: the SummaryMethod element of dataProcess()'s return value, the LABEL column in ProteinLevelData and ModelQC, the remove column in FeatureLevelData, and the columns that appear only for featureSubset = "highQuality" or label-based data.
- Clarified that MissingPercentage and ImputationPercentage are proportions between 0 and 1.
- `@param` raw now states it takes a data.frame, not the name of a data set.

## Testing

No changes required here. I ran devtools::document()

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have run the devtools::document() command after my changes and committed the added files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and context

The documentation for `dataProcess()` and `groupComparison()` did not match the current output fields. This update aligns the source documentation and generated `.Rd` files with the implemented outputs.

## Changes

- Updated `dataProcess()` documentation.
- Specified that `raw` accepts an MSstats long-format data frame.
- Renamed `NumMeasuredFeatures` to `NumMeasuredFeature`.
- Documented `SummaryMethod`, `LABEL`, `remove`, and conditional feature fields.
- Clarified missingness and imputation values as proportions from 0 to 1.
- Updated `groupComparison()` documentation with matching field names and label information.
- Regenerated the affected `.Rd` files.

## Tests

- No unit tests were added or modified.
- Existing tests cover `dataProcess()` and `groupComparison()`.
- `devtools::document()` completed without new warnings.

## Coding guidelines

- No coding guideline violations were identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->